### PR TITLE
Rename constants and make use of builtin random.choice()

### DIFF
--- a/assets/news_api.py
+++ b/assets/news_api.py
@@ -2,8 +2,7 @@ from GoogleNews import GoogleNews
 from datetime import date, timedelta
 import random
 
-
-def getnews(subject):
+def get_news(subject):
     googlenews = GoogleNews(lang='en')
     current_date = date.today()
     date_string = current_date.strftime("%m/%d/%Y")
@@ -13,10 +12,10 @@ def getnews(subject):
     result = googlenews.get_links()
     googlenews.clear()
     try:
-        return str(result[random.randint(0, len(result))])
+        return str(random.choice(result))
     except IndexError:
         date_string_previous_week = date.today() - timedelta(days=7)
         googlenews.set_time_range(date_string, date_string_previous_week.strftime("%m/%d/%Y"))
         googlenews.search(str(subject))
         result = googlenews.get_links()
-        return str(result[random.randint(0, len(result))])
+        return str(random.choice(result))

--- a/assets/nsfw_api.py
+++ b/assets/nsfw_api.py
@@ -1,7 +1,7 @@
 from pygelbooru import Gelbooru
 import datetime
 
-max_iteration = 50
+MAX_ITERATION = 50
 
 
 async def get_hentai(subject):
@@ -10,7 +10,7 @@ async def get_hentai(subject):
     gelbooru = Gelbooru()
     result = await gelbooru.random_post(tags=subject)
     iteration = 1
-    while result.rating == "s" and iteration <= max_iteration and datetime.datetime.now() <= deadline_time:
+    while result.rating == "s" and iteration <= MAX_ITERATION and datetime.datetime.now() <= deadline_time:
         iteration += 1
         result = await gelbooru.random_post(tags=[subject])
     if iteration >= 10:

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 import discord
 from discord.ext import commands
 import asyncio
-from assets import news_api
-from assets import nsfw_api
-time_sleep_const = 10
+from assets import nsfw_api, news_api
+SLEEP_TIME = 10
 
 
 def read_token():
@@ -17,7 +16,7 @@ client = commands.Bot(command_prefix='!')
 
 
 async def wait_and_delete_msgs(ctx, bot_msg):
-    await asyncio.sleep(time_sleep_const)
+    await asyncio.sleep(SLEEP_TIME)
     try:
         await ctx.message.delete()
     except discord.errors.NotFound:
@@ -31,7 +30,7 @@ async def wait_and_delete_msgs(ctx, bot_msg):
 @client.command()
 async def news(ctx, *, arg):
     try:
-        await ctx.reply('Here is the news : ' + news_api.getnews(arg), mention_author=False)
+        await ctx.reply('Here is the news : ' + news_api.get_news(arg), mention_author=False)
     except IndexError:
         bot_msg = await ctx.reply(
             r"Sorry no news have been found for this given subject ¯\_(ツ)_/¯", mention_author=False)


### PR DESCRIPTION
Hi.

In Python, there is no way to ensure a constant is a constant. So, the most ideal way to distinguish a constant
in python is through naming convention. Please use MY_CONSTANT instead of my_constant.

This patch also make use of `random.choice()` for choosing random element from a list.

Thanks for reviewing.

Signed-off-by: Momozor